### PR TITLE
Only interpolate at non-terminal next states

### DIFF
--- a/src/local_approximation_vi.jl
+++ b/src/local_approximation_vi.jl
@@ -140,8 +140,13 @@ function solve(solver::LocalApproximationValueIterationSolver, mdp::Union{MDP,PO
                         # Generative Model
                         for j in 1:solver.n_generative_samples
                             sp, r = generate_sr(mdp, s, a, solver.rng)
-                            sp_point = POMDPs.convert_s(Vector{Float64}, sp, mdp)
-                            u += r + discount_factor*compute_value(policy.interp, sp_point)
+                            u += r
+
+                            # Only interpolate sp if it is non-terminal
+                            if !isterminal(mdp,sp)
+                                sp_point = POMDPs.convert_s(Vector{Float64}, sp, mdp)
+                                u += discount_factor*compute_value(policy.interp, sp_point)
+                            end
                         end
                         u = u / solver.n_generative_samples
                     else
@@ -150,8 +155,13 @@ function solve(solver::LocalApproximationValueIterationSolver, mdp::Union{MDP,PO
                         for (sp, p) in weighted_iterator(dist)
                             p == 0.0 ? continue : nothing
                             r = reward(mdp, s, a, sp)
-                            sp_point = POMDPs.convert_s(Vector{Float64}, sp, mdp)
-                            u += p * (r + discount_factor*compute_value(policy.interp, sp_point))
+                            u += p*r
+
+                            # Only interpolate sp if it is non-terminal
+                            if !isterminal(mdp,sp)
+                                sp_point = POMDPs.convert_s(Vector{Float64}, sp, mdp)
+                                u += p * (discount_factor*compute_value(policy.interp, sp_point))
+                            end
                         end # next-states
                     end
                     
@@ -222,8 +232,13 @@ function action_value(policy::LocalApproximationValueIterationPolicy, s::S, a::A
     if policy.is_mdp_generative
         for j in 1:policy.n_generative_samples
             sp, r = generate_sr(mdp, s, a, Base.GLOBAL_RNG)
-            sp_point = POMDPs.convert_s(Vector{Float64}, sp, mdp)
-            u += r + discount_factor*compute_value(policy.interp, sp_point)
+            u += r
+
+            # Only interpolate sp if it is non-terminal
+            if !isterminal(mdp,sp)
+                sp_point = POMDPs.convert_s(Vector{Float64}, sp, mdp)
+                u += discount_factor*compute_value(policy.interp, sp_point)
+            end
         end
         u = u / policy.n_generative_samples
     else
@@ -231,8 +246,13 @@ function action_value(policy::LocalApproximationValueIterationPolicy, s::S, a::A
         for (sp, p) in weighted_iterator(dist)
             p == 0.0 ? continue : nothing
             r = reward(mdp, s, a, sp)
-            sp_point = POMDPs.convert_s(Vector{Float64}, sp, mdp)
-            u += p * (r + discount_factor*compute_value(policy.interp, sp_point))
+            u += p*r
+
+            # Only interpolate sp if it is non-terminal
+            if !isterminal(mdp,sp)
+                sp_point = POMDPs.convert_s(Vector{Float64}, sp, mdp)
+                u += p*(discount_factor*compute_value(policy.interp, sp_point))
+            end
         end
     end
 

--- a/src/local_approximation_vi.jl
+++ b/src/local_approximation_vi.jl
@@ -6,16 +6,14 @@ mutable struct LocalApproximationValueIterationSolver{I<:LocalFunctionApproximat
     rng::RNG # Seed if req'd
     is_mdp_generative::Bool # Whether to treat underlying MDP model as generative
     n_generative_samples::Int64 # If underlying model generative, how many samples to use
-    terminal_costs_set::Bool # The utility of terminal states has been set and should not be modified
 end
 
 # Default constructor
 function LocalApproximationValueIterationSolver{I<:LocalFunctionApproximator, RNG<:AbstractRNG}(interp::I;
                                                                                                 max_iterations::Int64=100, belres::Float64=1e-3,
                                                                                                 verbose::Bool=false, rng::RNG=Base.GLOBAL_RNG,
-                                                                                                is_mdp_generative::Bool=false, n_generative_samples::Int64=0,
-                                                                                                terminal_costs_set::Bool=false)
-    return LocalApproximationValueIterationSolver(interp,max_iterations, belres, verbose, rng, is_mdp_generative, n_generative_samples, terminal_costs_set)
+                                                                                                is_mdp_generative::Bool=false, n_generative_samples::Int64=0)
+    return LocalApproximationValueIterationSolver(interp,max_iterations, belres, verbose, rng, is_mdp_generative, n_generative_samples)
 end
 
 # Unparameterized constructor just for getting requirements
@@ -124,9 +122,7 @@ function solve(solver::LocalApproximationValueIterationSolver, mdp::Union{MDP,PO
             sub_aspace = actions(mdp,s)
 
             if isterminal(mdp, s)
-                if !solver.terminal_costs_set
-                    interp_values[istate] = 0.0
-                end
+                interp_values[istate] = 0.0
             else
                 old_util = interp_values[istate]
                 max_util = -Inf

--- a/test/runtests_versus_discrete_vi.jl
+++ b/test/runtests_versus_discrete_vi.jl
@@ -34,8 +34,7 @@ function test_against_full_grid()
 
     # Solve with discrete VI
     solver = ValueIterationSolver(max_iterations=1000)
-    policy = create_policy(solver, mdp)
-    policy = solve(solver, mdp, policy, verbose=true)
+    policy = solve(solver, mdp, verbose=true)
 
     # Setup grid with 0.1 resolution
     # As we increase VERTICES_PER_AXIS, the error should reduce


### PR DESCRIPTION
In the value iteration and action value functions, a check is made that the `sp` next state is non-terminal before the interpolated value at `sp` is used to update the utility at `s`. This is relevant for settings with terminal actions where the `sp` is a meaningless state constructed by the user to be a terminal state.