### PR TITLE
Fixing requirements for POMDPs v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LocalApproximationValueIteration"
 uuid = "a40420fb-f401-52da-a663-f502e5b95060"
 repo = "https://github.com/JuliaPOMDP/LocalApproximationValueIteration.jl"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 LocalFunctionApproximation = "db97f5ab-fc25-52dd-a8f9-02a257c35074"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+POMDPModels = "0.4.1"
 POMDPs = "0.7.3, 0.8"
 julia = "1"
 

--- a/src/local_approximation_vi.jl
+++ b/src/local_approximation_vi.jl
@@ -61,7 +61,7 @@ end
 
     # Have different requirements depending on whether solver MDP is generative or explicit
     if solver.is_mdp_generative
-        @req generate_sr(::P, ::S, ::A, ::typeof(solver.rng))
+        @req gen(::DDNOut{(:sp, :r)}, ::P, ::S, ::A, ::typeof(solver.rng))
     else
         @req transition(::P, ::S, ::A)
         pts = get_all_interpolating_points(solver.interp)
@@ -126,7 +126,6 @@ function POMDPs.solve(solver::LocalApproximationValueIterationSolver, mdp::Union
                 max_util = -Inf
 
                 for a in sub_aspace
-                    iaction = actionindex(mdp, a)
                     u::Float64 = 0.0
 
                     # Do bellman backup based on generative / explicit model


### PR DESCRIPTION
1. Updating`@req generate_sr` to `@req gen`
2. Removes unnecessary call to `actionindex`